### PR TITLE
Fix typo in the repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/weitblicken/multi-expose-loader",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wetiblicken/multi-expose-loader.git"
+    "url": "https://github.com/weitblicken/multi-expose-loader.git"
   },
   "bugs": "https://github.com/weitblicken/multi-expose-loader/issues",
   "bin": "",


### PR DESCRIPTION
This link is broken:

![image](https://user-images.githubusercontent.com/153412/46546198-14f32800-c8d1-11e8-8469-2f78907c22ec.png)
